### PR TITLE
Handle HTTPError 404 in download.py

### DIFF
--- a/cygnss_wetlands/cygnss/download.py
+++ b/cygnss_wetlands/cygnss/download.py
@@ -109,7 +109,7 @@ def http_download_by_date(
                     shutil.copyfileobj(response, f)
                     success_download_list.append(dest_dir.joinpath(filename))
 
-            except requests.exceptions.HTTPError as e:
+            except (requests.exceptions.HTTPError, urllib.error.URLError) as e:
 
                 # handle any errors here
                 print(f"Could not download file: {filename}, error: {e}")


### PR DESCRIPTION
Resolves #1 

New error message:
`Could not download file: cyg04.ddmi.s20200131-000000-e20200131-235959.l1.power-brcs.a31.d32.nc, error: HTTP Error 404: Not Found`