### PR TITLE
Bug/5/resolve earthdata service unavailable

### DIFF
--- a/cygnss_wetlands/cygnss/cli.py
+++ b/cygnss_wetlands/cygnss/cli.py
@@ -94,6 +94,9 @@ def download(
     # Iterate over each date
     date_list = [start_date + datetime.timedelta(days=x) for x in range((end_date - start_date).days + 1)]
 
+    successful_downloads = []
+    failed_downloads = []
+
     for date in date_list:
 
         # Organize destination subfolder, change current work directory to this
@@ -107,8 +110,11 @@ def download(
         # Download all files from this date
         successFileList, failedFileList = http_download_by_date(product_level, date, dest_subdir, overwrite)
 
-    print(f"Successfully downloaded: {successFileList}")
-    print(f"Failed to download: {failedFileList}")
+        successful_downloads.extend(fileName for fileName in successFileList)
+        failed_downloads.extend(fileName for fileName in failedFileList)
+
+    print(f"Successfully downloaded: {successful_downloads}")
+    print(f"Failed to download: {failed_downloads}")
 
 
 def entry():

--- a/cygnss_wetlands/cygnss/cli.py
+++ b/cygnss_wetlands/cygnss/cli.py
@@ -105,10 +105,10 @@ def download(
             os.makedirs(dest_subdir)
 
         # Download all files from this date
-        # TODO: add a log to keep track of files that are downloaded - and any failures
-        filelist = http_download_by_date(product_level, date, dest_subdir, overwrite)
+        successFileList, failedFileList = http_download_by_date(product_level, date, dest_subdir, overwrite)
 
-    print(f"Successfully downloaded: {filelist}")
+    print(f"Successfully downloaded: {successFileList}")
+    print(f"Failed to download: {failedFileList}")
 
 
 def entry():

--- a/cygnss_wetlands/cygnss/download.py
+++ b/cygnss_wetlands/cygnss/download.py
@@ -1,7 +1,7 @@
 import base64
 import datetime
 import json
-import os.path
+import os
 import shutil
 import urllib
 from http.cookiejar import CookieJar

--- a/cygnss_wetlands/cygnss/download.py
+++ b/cygnss_wetlands/cygnss/download.py
@@ -147,7 +147,8 @@ def http_download_by_date(
                         # Check the file size; if it's not the same, notify the user and overwrite
                         localFileSize = int(os.path.getsize(complete_filepath))
                         sourceFileSize = int(response.headers["Content-Length"])
-                        if localFileSize != sourceFileSize:
+                        # If Earthdata system is down the source file will be smaller than the valid local file
+                        if localFileSize < sourceFileSize:
                             with open(complete_filepath, "wb") as f:
                                 print(
                                     f"Identified data with a local file size ({localFileSize}) different than source ({sourceFileSize}); Redownloading {filename}"

--- a/cygnss_wetlands/cygnss/download.py
+++ b/cygnss_wetlands/cygnss/download.py
@@ -60,7 +60,7 @@ def validate_download(filePath):
     Returns:
         bool: True if valid file, False if file fragment
     """
-    # Size of file fragment indicating the Earthdata Service is unavailable
+    # Size of file fragment indicating the Earthdata Service is unavailable; See #5
     fileFragmentSize = 95234
 
     if filePath.exists():
@@ -74,11 +74,7 @@ def validate_download(filePath):
 
 
 def http_download_by_date(
-    product_level: CygnssProductLevel,
-    date: datetime.datetime,
-    dest_dir: Path,
-    overwrite: bool = False,
-    validateFileSize: bool = True,
+    product_level: CygnssProductLevel, date: datetime.datetime, dest_dir: Path, overwrite: bool = False
 ) -> List:
     """
     Download CYGNSS data files to local from PODAAC HTTP site
@@ -125,58 +121,51 @@ def http_download_by_date(
 
         complete_filepath = dest_dir.joinpath(filename)
 
-        if not complete_filepath.exists() or (complete_filepath.exists() and (overwrite or validateFileSize)):
-            downloaded = False
+        downloaded = False
 
-            url = f'{config["download"]["http"]}/CYGNSS_{product_level.name}_{config[product_level.name]["product_version"].upper()}/{filename}'
+        url = f'{config["download"]["http"]}/CYGNSS_{product_level.name}_{config[product_level.name]["product_version"].upper()}/{filename}'
 
-            try:
-                # Create and submit the request. There are a wide range of exceptions that
-                # can be thrown here, including HTTPError and URLError. These should be
-                # caught and handled.
-                request = urllib.request.Request(url)
+        try:
+            # Create and submit the request. There are a wide range of exceptions that
+            # can be thrown here, including HTTPError and URLError. These should be
+            # caught and handled.
+            request = urllib.request.Request(url)
 
-                with urllib.request.urlopen(request) as response:
-                    # If the file exists and either we're overwriting the data or checking for invalid data
-                    if complete_filepath.exists():
-                        # If overwrite is flagged, automatically overwrite the data
-                        if overwrite:
-                            with open(complete_filepath, "wb") as f:
-                                print(f"Downloading: {filename}")
-                                shutil.copyfileobj(response, f)
-                                downloaded = True
-                        elif validateFileSize:
-                            # Check the file size; if it's not the same, notify the user and overwrite
-                            localFileSize = int(os.path.getsize(complete_filepath))
-                            sourceFileSize = int(response.headers["Content-Length"])
-                            if localFileSize != sourceFileSize:
-                                with open(complete_filepath, "wb") as f:
-                                    print(
-                                        f"Identified data with a local file size ({localFileSize}) different than source ({sourceFileSize}); Redownloading {filename}"
-                                    )
-                                    shutil.copyfileobj(response, f)
-                                    downloaded = True
-                            else:
-                                print(f"Skipping {filename}, valid local copy exists and overwrite not flagged")
-                        else:
-                            # This should never be hit
-                            print(f"Skipping {filename}, local copy exists and overwrite/validate not flagged")
-                    else:
-                        # If the file does not currently exist, download the file
+            with urllib.request.urlopen(request) as response:
+                # If the file exists and either we're overwriting the data or checking for invalid data
+                if complete_filepath.exists():
+                    # If overwrite is flagged, automatically overwrite the data
+                    if overwrite:
                         with open(complete_filepath, "wb") as f:
                             print(f"Downloading: {filename}")
                             shutil.copyfileobj(response, f)
                             downloaded = True
+                    else:
+                        # Check the file size; if it's not the same, notify the user and overwrite
+                        localFileSize = int(os.path.getsize(complete_filepath))
+                        sourceFileSize = int(response.headers["Content-Length"])
+                        if localFileSize != sourceFileSize:
+                            with open(complete_filepath, "wb") as f:
+                                print(
+                                    f"Identified data with a local file size ({localFileSize}) different than source ({sourceFileSize}); Redownloading {filename}"
+                                )
+                                shutil.copyfileobj(response, f)
+                                downloaded = True
+                        else:
+                            print(f"Skipping {filename}, valid local copy exists and overwrite not flagged")
+                else:
+                    # If the file does not currently exist, download the file
+                    with open(complete_filepath, "wb") as f:
+                        print(f"Downloading: {filename}")
+                        shutil.copyfileobj(response, f)
+                        downloaded = True
 
-            except (requests.exceptions.HTTPError, urllib.error.URLError) as e:
-                # handle any errors here
-                print(f"Could not download file: {filename}, error: {e}")
+        except (requests.exceptions.HTTPError, urllib.error.URLError) as e:
+            # handle any errors here
+            print(f"Could not download file: {filename}, error: {e}")
 
-            # After downloading or receiving an error, validate the file isn't a fragment
-            if validate_download(complete_filepath) and downloaded:
-                success_download_list.append(dest_dir.joinpath(filename))
-
-        else:
-            print(f"Skipping {filename}, local copy exists and overwrite/validate not flagged")
+        # After downloading or receiving an error, validate the file isn't a fragment
+        if validate_download(complete_filepath) and downloaded:
+            success_download_list.append(dest_dir.joinpath(filename))
 
     return success_download_list

--- a/cygnss_wetlands/cygnss/download.py
+++ b/cygnss_wetlands/cygnss/download.py
@@ -87,6 +87,10 @@ def http_download_by_date(
         product_level (CygnssProductLevel):
         datetime (datetime.datetime)
         dest_dir (Path): Destination download directory
+
+    Returns:
+        success_download_list (List): List of files that were successfully downloaded
+        failed_download_list (List): List of files that failed to download
     """
     password_manager = urllib.request.HTTPPasswordMgrWithDefaultRealm()
     password_manager.add_password(
@@ -111,6 +115,7 @@ def http_download_by_date(
     spacecraft_id_list = np.arange(1, 8 + 1)
 
     success_download_list = []
+    failed_download_list = []
 
     # Attempt to download file for given spacecraft
     # (not all spacecrafts necessarily have data for every day )
@@ -168,9 +173,10 @@ def http_download_by_date(
         except (requests.exceptions.HTTPError, urllib.error.URLError) as e:
             # handle any errors here
             print(f"Could not download file: {filename}, error: {e}")
+            failed_download_list.append(dest_dir.joinpath(filename))
 
         # After downloading or receiving an error, validate the file isn't a fragment
         if validate_download(complete_filepath, downloaded) and downloaded:
             success_download_list.append(dest_dir.joinpath(filename))
 
-    return success_download_list
+    return success_download_list, failed_download_list

--- a/cygnss_wetlands/cygnss/download.py
+++ b/cygnss_wetlands/cygnss/download.py
@@ -48,25 +48,26 @@ def get_s3_credentials(s3_endpoint: str = "https://archive.podaac.earthdata.nasa
 
 def validate_download(filePath, newDownload):
     """
-    Occasionally PODAAC will return file fragments indicating "Sorry, the Earthdata Service is currently unavailable." See #5.
+    Occasionally PODAAC will return a system down notification in the form of a file indicating
+    "Sorry, the Earthdata Service is currently unavailable." See #5.
 
-    The file fragments are 95,234 bytes in size.
+    The system down notification files are 95,234 bytes in size.
 
-    Remove the file fragment if detected.
+    Remove the system down notification if detected as this will cause exceptions elsewhere.
 
     Args:
-        filePath (Path)
+        filePath (Path): Complete path to file
         newDownload (bool): Indicates if the file was just downloaded
 
     Returns:
         bool: True if valid file, False if file fragment
     """
     # Size of file fragment indicating the Earthdata Service is unavailable; See #5
-    fileFragmentSize = 95234
+    systemDownNotificationFileSize = 95234
 
     if filePath.exists():
         localFileSize = int(os.path.getsize(filePath))
-        if localFileSize > fileFragmentSize:
+        if localFileSize > systemDownNotificationFileSize:
             return True
         else:
             if newDownload:

--- a/cygnss_wetlands/cygnss/download.py
+++ b/cygnss_wetlands/cygnss/download.py
@@ -60,7 +60,7 @@ def validate_download(filePath, newDownload):
         newDownload (bool): Indicates if the file was just downloaded
 
     Returns:
-        bool: True if valid file, False if file fragment
+        bool: True if valid file, False if system down notification
     """
     # Size of file fragment indicating the Earthdata Service is unavailable; See #5
     systemDownNotificationFileSize = 95234

--- a/cygnss_wetlands/cygnss/download.py
+++ b/cygnss_wetlands/cygnss/download.py
@@ -46,7 +46,7 @@ def get_s3_credentials(s3_endpoint: str = "https://archive.podaac.earthdata.nasa
     return json.loads(results.content)
 
 
-def validate_download(filePath):
+def validate_download(filePath, newDownload):
     """
     Occasionally PODAAC will return file fragments indicating "Sorry, the Earthdata Service is currently unavailable." See #5.
 
@@ -56,6 +56,7 @@ def validate_download(filePath):
 
     Args:
         filePath (Path)
+        newDownload (bool): Indicates if the file was just downloaded
 
     Returns:
         bool: True if valid file, False if file fragment
@@ -68,6 +69,8 @@ def validate_download(filePath):
         if localFileSize > fileFragmentSize:
             return True
         else:
+            if newDownload:
+                print("The Earthdata Service may be currently unavailable.")
             print(f"File fragment detected and removed: {filePath}")
             os.remove(filePath)
             return False
@@ -165,7 +168,7 @@ def http_download_by_date(
             print(f"Could not download file: {filename}, error: {e}")
 
         # After downloading or receiving an error, validate the file isn't a fragment
-        if validate_download(complete_filepath) and downloaded:
+        if validate_download(complete_filepath, downloaded) and downloaded:
             success_download_list.append(dest_dir.joinpath(filename))
 
     return success_download_list

--- a/cygnss_wetlands/cygnss/download.py
+++ b/cygnss_wetlands/cygnss/download.py
@@ -48,11 +48,11 @@ def get_s3_credentials(s3_endpoint: str = "https://archive.podaac.earthdata.nasa
 
 def validate_download(filePath):
     """
-    Occasionally PODAAC will return file fragments indicating "Sorry, the Earthdata Service is currently unavailable."
+    Occasionally PODAAC will return file fragments indicating "Sorry, the Earthdata Service is currently unavailable." See #5.
 
     The file fragments are 95,234 bytes in size.
 
-    Remove these file fragments.
+    Remove the file fragment if detected.
 
     Args:
         filePath (Path)


### PR DESCRIPTION
Resolves #5 

1. Validates that the file size stored locally is the same size as the file on the server; if not, download the server file. The file sizes could differ if there was a download error, if internet went out, if the download was cancelled, or if podaacs server is unavailable
2. Checks if the downloaded / skipped local file is the same size as the PODAAC service unavailable file described in #5; deletes if so

Ultimately, this should make downloading more robust and enable larger scale data analysis without manually reviewing and downloading missing/invalid data

Optionally we could remove 1 as a parameter and do it by default. This would make the application more robust but less efficient as we would do this check for every file download. Let me know your thoughts.